### PR TITLE
Compile CV to a PDF file using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+resume.pdf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM texlive/texlive:latest
+
+# Install any additional required packages
+RUN tlmgr update --self && \
+  tlmgr install fontawesome unicode-math enumitem ragged2e xifthen ifmtarg
+
+# Set the working directory
+WORKDIR /resume
+
+# Copy all necessary files
+COPY resume.tex /resume/
+COPY awesome-cv.cls /resume/
+COPY fontawesome.sty /resume/
+COPY fonts/ /resume/fonts/
+
+# Compile the resume
+RUN xelatex resume.tex
+
+# Create an output directory
+RUN mkdir -p /output
+
+# Copy the generated PDF to the output directory
+RUN cp resume.pdf /output/
+
+# Set the default command to provide the path to the PDF
+CMD ["echo", "Resume has been compiled. The PDF is available at '/output/resume.pdf'"] 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,52 @@
-## Usage
-To generate a PDF from this LaTeX code, navigate to this folder in a terminal and run:
-```
-sudo apt install texlive-xetex
-xelatex resume.tex
-```
-## Requirements
-You will need to have `xelatex` installed on your machine.
+# Resume Builder with Docker
 
-Alternatively, you can use a site like [ShareLaTeX](https://sharelatex.com) to build and edit your LaTeX instead.
+This project contains a LaTeX resume that can be compiled to PDF using Docker without installing any LaTeX tools locally.
+
+## Requirements
+
+- Docker installed on your system
+
+## How to Compile the Resume
+
+1. Make sure Docker is running on your system
+2. Run the build script:
+
+   ```bash
+   ./build-resume.sh
+   ```
+
+3. The compiled PDF will be available as `resume.pdf` in the project root
+
+## Project Structure
+
+- `resume.tex`: The main LaTeX file containing your resume content
+- `awesome-cv.cls`: The LaTeX class file for the resume template
+- `fonts/`: Directory containing required fonts
+- `fontawesome.sty`: Font Awesome style file for icons
+- `Dockerfile`: Docker configuration for compiling the resume
+- `build-resume.sh`: Script for building and running the Docker container
+
+## Customizing Your Resume
+
+To update your resume:
+
+1. Edit the `resume.tex` file with your information
+2. Run the build script again to generate a new PDF
+
+## Manual Docker Commands
+
+If you prefer to run the Docker commands manually:
+
+```bash
+# Build the Docker image
+docker build -t resume-builder .
+
+# Run the container
+docker run --name resume-container resume-builder
+
+# Copy the PDF to your local machine
+docker cp resume-container:/output/resume.pdf ./resume.pdf
+
+# Remove the container
+docker rm resume-container
+```

--- a/build-resume.sh
+++ b/build-resume.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Build the Docker image
+echo "Building Docker image..."
+docker build -t resume-builder .
+
+# Run the container and copy the PDF to the current directory
+echo "Compiling resume..."
+docker run --name resume-container resume-builder
+
+# Copy the PDF from the container to the host
+echo "Copying PDF to current directory..."
+docker cp resume-container:/output/resume.pdf ./resume.pdf
+
+# Clean up
+echo "Cleaning up..."
+docker rm resume-container
+
+echo "Done! Your resume is available as resume.pdf in the current directory." 


### PR DESCRIPTION
Creates a `Dockerfile` and a script `build-resume.sh` to compile cvs without having to install `XeLaTeX` locally. Outputs a `pdf` file version of the CV.